### PR TITLE
Fix sensor initialization on 64-bit OS

### DIFF
--- a/src/ioctl.jl
+++ b/src/ioctl.jl
@@ -33,5 +33,5 @@ function ioctl(fd::Cint, request::Integer, arg)
 end
 
 ioctl(f::Union{Base.Filesystem.File, IOStream}, request::Integer, arg) =
-    ioctl(fd(f), request, arg)
+    ioctl(Cint(fd(f)), request, arg)
     


### PR DESCRIPTION
When using the 64-bit version of Raspberry Pi OS, sensor initialization fails because the address passed to `ioctl` is not a `Cint` (ie. `Int32`).

Hopefully a new release could be made once this is merged.